### PR TITLE
fix: correct JWE j2 filename in fs-apim-mediation-artifacts pom.xml

### DIFF
--- a/fs-apim-mediation-artifacts/pom.xml
+++ b/fs-apim-mediation-artifacts/pom.xml
@@ -123,7 +123,7 @@
                                     <fileset
                                             dir="../common/jwe-payload-processing">
                                         <filename
-                                                name="consentEnforcementPolicy.j2"/>
+                                                name="jwePayloadProcessingRequestPolicy.j2"/>
                                     </fileset>
                                 </copy>
                                 <!-- Copying j2 files to folder -->


### PR DESCRIPTION
The copy task for jwe-payload-processing was referencing consentEnforcementPolicy.j2 instead of
jwePayloadProcessingRequestPolicy.j2 due to a copy-paste error, causing the JWE policy template to be missing from the build ZIP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the payload processing policy configuration in the build system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->